### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16512,5 +16512,12 @@
     "description": "Fetch data from multiple sources (REST APIs, RPC, gRPC, GraphQL) and insert results into notes",
     "repo": "qf3l3k/obsidian-api-fetcher"
   }
+{
+	"id": "Eccidian-plugin",
+	"name": "Eccidian Encrypt",
+	"author": "Entropiex",
+	"description": "Encrypt your notes using advanced encryption algorithms.",
+    	"repo": "Enthalpiex/Eccidian-Encrypt"
+}
 ]
 


### PR DESCRIPTION
Add Eccidian plugin entry

This PR adds the Eccidian plugin, which enables password-based AES and ECC encryption for Obsidian notes using a `.eccidian` file format.
